### PR TITLE
fix(llm): complete path-less OpenAI-compatible base URLs

### DIFF
--- a/server/nodes/model/_local_validator.py
+++ b/server/nodes/model/_local_validator.py
@@ -45,6 +45,7 @@ import httpx
 import lmstudio
 import ollama
 from core.logging import get_logger
+from services.llm.config import normalize_openai_base_url
 from services.plugin.deps import get_auth_service
 from services.status_broadcaster import get_status_broadcaster
 
@@ -258,6 +259,12 @@ async def validate_local_llm(data: Dict[str, Any]) -> Dict[str, Any]:
 
     if not base_url:
         return {"success": False, "valid": False, "error": "Base URL required"}
+
+    # Store the OpenAI-compatible base, not whatever the user pasted: the
+    # runtime reads this value straight into the SDK's ``base_url``, and a
+    # bare host:port silently produces a POST to ``/chat/completions``.
+    # The probe helpers below strip the suffix again for the vendor SDKs.
+    base_url = normalize_openai_base_url(base_url)
 
     auth_service = get_auth_service()
 

--- a/server/services/llm/config.py
+++ b/server/services/llm/config.py
@@ -34,6 +34,43 @@ class ProviderConfig:
 
 
 # ---------------------------------------------------------------------------
+# Base-URL normalization (shared with the local-LLM credential validator)
+# ---------------------------------------------------------------------------
+
+
+def normalize_openai_base_url(base_url: str) -> str:
+    """Return ``base_url`` as a usable OpenAI-compatible base (``.../v1``).
+
+    The OpenAI SDK appends ``chat/completions`` **relative to the base URL**,
+    so a bare ``http://host:port`` — the natural thing to paste for a local
+    server, and what LM Studio's own UI displays — makes the runtime POST to
+    ``http://host:port/chat/completions``, which is not a route.
+
+    That failure mode is unusually hard to read, which is why the completion
+    happens here and not only where the URL is stored:
+
+    * The credential validator can't catch it. Model listing goes through the
+      vendor SDKs (LM Studio's native WebSocket, Ollama's REST API), which are
+      happy with the bare host — so the URL validates and only chat breaks.
+    * LM Studio answers the wrong path with **HTTP 200** and a body of
+      ``{"error": "Unexpected endpoint or method. (POST /chat/completions)"}``.
+      The SDK therefore raises nothing, the response parses to empty content,
+      and the agent reports "AI generated empty response" — a message that
+      points at the model instead of at the URL.
+
+    Only a URL with **no path** is completed. One that already carries a path
+    (``/v1``, or a gateway path like ``/openai`` for LiteLLM) is returned
+    untouched: those are deliberate, and rewriting them breaks a working setup.
+    """
+    u = (base_url or "").strip().rstrip("/")
+    if not u:
+        return u
+    from urllib.parse import urlsplit
+
+    return u if urlsplit(u).path else f"{u}/v1"
+
+
+# ---------------------------------------------------------------------------
 # Load config/llm_defaults.json once at import time
 # ---------------------------------------------------------------------------
 

--- a/server/services/llm/providers/openai.py
+++ b/server/services/llm/providers/openai.py
@@ -44,7 +44,13 @@ class OpenAIProvider:
         }
         url = proxy_url or base_url
         if url:
-            kwargs["base_url"] = url
+            # A user-supplied local URL is routinely a bare host:port, which
+            # the SDK would turn into POST /chat/completions. See
+            # ``normalize_openai_base_url`` for why this is completed here and
+            # not only where the URL is persisted.
+            from services.llm.config import normalize_openai_base_url
+
+            kwargs["base_url"] = normalize_openai_base_url(url)
             if proxy_url:
                 kwargs["api_key"] = "ollama"
         self._client = openai.AsyncOpenAI(**kwargs)

--- a/server/tests/llm/test_base_url_normalization.py
+++ b/server/tests/llm/test_base_url_normalization.py
@@ -1,0 +1,67 @@
+"""Base-URL completion for OpenAI-compatible endpoints.
+
+Regression cover for the LM Studio failure mode: a stored proxy URL of
+``http://host:port`` (no path) made the OpenAI SDK POST to
+``/chat/completions``. LM Studio answers that path with **HTTP 200** and an
+``{"error": ...}`` body, so nothing raises and the agent reports an empty
+response instead of a routing mistake.
+
+Two invariants:
+
+1. ``normalize_openai_base_url`` completes a path-less URL to ``/v1`` and
+   leaves any explicit path alone (a gateway may serve ``/openai``).
+2. ``OpenAIProvider`` applies it at the point of use, so a URL already
+   persisted without ``/v1`` works without the operator re-entering it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.llm.config import normalize_openai_base_url
+from services.llm.providers.openai import OpenAIProvider
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        # The failure case: bare host:port gets the OpenAI-compat suffix.
+        ("http://192.168.4.93:1234", "http://192.168.4.93:1234/v1"),
+        ("http://localhost:1234/", "http://localhost:1234/v1"),
+        ("  http://localhost:1234  ", "http://localhost:1234/v1"),
+        ("https://example.com", "https://example.com/v1"),
+        # Already complete: untouched (beyond the trailing-slash trim).
+        ("http://localhost:1234/v1", "http://localhost:1234/v1"),
+        ("http://localhost:1234/v1/", "http://localhost:1234/v1"),
+        # An explicit path is the operator's choice — a gateway may mount the
+        # OpenAI surface anywhere. Never rewrite it.
+        ("https://gw.example.com/openai", "https://gw.example.com/openai"),
+        ("https://gw.example.com/api/v2", "https://gw.example.com/api/v2"),
+        # Empty stays empty: the caller decides whether that's an error.
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_normalize_openai_base_url(given, expected):
+    assert normalize_openai_base_url(given) == expected
+
+
+@pytest.mark.parametrize("kwarg", ["proxy_url", "base_url"])
+def test_provider_completes_path_less_url(kwarg):
+    """Whichever way the URL arrives, the SDK receives the ``/v1`` base."""
+    with patch("openai.AsyncOpenAI", MagicMock()) as client:
+        OpenAIProvider("k", provider_name="lmstudio", **{kwarg: "http://192.168.4.93:1234"})
+    assert client.call_args.kwargs["base_url"] == "http://192.168.4.93:1234/v1"
+
+
+def test_provider_leaves_explicit_path_alone():
+    with patch("openai.AsyncOpenAI", MagicMock()) as client:
+        OpenAIProvider("k", base_url="https://gw.example.com/openai")
+    assert client.call_args.kwargs["base_url"] == "https://gw.example.com/openai"
+
+
+def test_provider_without_url_passes_no_base_url():
+    """Plain OpenAI must keep the SDK's own default endpoint."""
+    with patch("openai.AsyncOpenAI", MagicMock()) as client:
+        OpenAIProvider("k")
+    assert "base_url" not in client.call_args.kwargs


### PR DESCRIPTION
Fixes #114.

## Problem

A stored local base URL of `http://host:port` made the OpenAI SDK POST to `/chat/completions` instead of `/v1/chat/completions` — the SDK appends the path *relative* to `base_url`.

The failure mode is worth spelling out, because it is why this reads as a user error: **LM Studio answers the wrong path with HTTP 200** and a body of `{"error":"Unexpected endpoint or method. (POST /chat/completions)"}`. Nothing raises, so the agent reports `AI generated empty response` instead of a routing mistake.

The credential validator could not catch it either — `_fetch_lmstudio_models` probes over LM Studio's native WebSocket API (`ws://host:port/llm`), which is happy without the `/v1` suffix, so the URL validated green and only chat failed. `_strip_v1_path` shows the stored shape was already *expected* to end in `/v1`; nothing enforced it.

## Fix

`normalize_openai_base_url` in `services/llm/config.py` completes the URL **only when it carries no path**, so an explicit gateway path such as `/openai` or `/api/v2` is left alone — appending `/v1` there would break a working configuration.

One implementation, applied at two points:

- `services/llm/providers/openai.py` — at the point of use, which makes an **already-stored** URL work without the operator re-entering it. This covers Ollama too, which shares the provider class and the same `{provider}_proxy` shape.
- `nodes/model/_local_validator.py` — when the URL is persisted, so new entries are stored canonically.

## Verification

Live against an LM Studio server with no `/v1` stored: the same provider path that returned an empty response now returns a completion (`base_url -> http://host:1234/v1/`, content `'ok'`, usage reported).

14 new tests in `server/tests/llm/test_base_url_normalization.py`: bare `host:port` -> `/v1`, an already-`/v1` URL unchanged, a gateway path unchanged, empty and `None`, the provider applying the completion whether the URL arrives via `proxy_url` or `base_url`, and plain OpenAI still passing no `base_url` at all so the SDK keeps its own default endpoint.

Run on this branch (cherry-picked onto current `main`, applied clean): `tests/llm` + `test_plugin_contract.py` + `test_plugin_self_containment.py` -> 326 passed, 36 deselected.

## Out of scope, noted in the issue

An HTTP 200 carrying an `{"error": ...}` body should surface as a real error rather than an empty response. That is a separate change in `openai.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)